### PR TITLE
added productfeatures to StartSession params

### DIFF
--- a/rifec.pl
+++ b/rifec.pl
@@ -1158,10 +1158,11 @@ package RIFEC::Handler {
 
         my %paramspec_of = (
             "ns1:StartSession" => {
-                'macaddress'            => { regex => $macaddress },
-                'transfermodetimestamp' => { regex => $number     },
-                'cnonce'                => { regex => $md5sum     },
-                'transfermode'          => { regex => $number     },
+                'macaddress'            => { regex => $macaddress            },
+                'transfermodetimestamp' => { regex => $number                },
+                'cnonce'                => { regex => $md5sum                },
+                'transfermode'          => { regex => $number                },
+                'productfeatures'       => { regex => $number, optional => 1 },
             },
             "ns1:GetPhotoStatus" => {
                 'filesize'      => { regex => $number                        },


### PR DESCRIPTION
i have a new "eyefi mobiPRO 32GB+WiFi SDHC class10" and it failed to upload images because it is sending a productfeatures param.

this patch allows this extra param.