### PR TITLE
Use filetest 'access'

### DIFF
--- a/rifec.pl
+++ b/rifec.pl
@@ -31,6 +31,7 @@ require 5.014;
 
 use strict;
 use warnings;
+use filetest 'access';
 
 my $log;
 my $config;


### PR DESCRIPTION
This makes `-w` etc. respect ACLs, NFS access control and other extensions to regular file mode permissions.
